### PR TITLE
fix: 修复 steam.js 的 typo 导致的 bug

### DIFF
--- a/lib/steam.js
+++ b/lib/steam.js
@@ -130,5 +130,5 @@ export async function gen_steam(sid) {
 
   data["format"] = descr.trim();
   data["success"] = true; // 更新状态为成功
-  returndata;
+  return data;
 }


### PR DESCRIPTION
虽然 Steam 的相关功能因为 CF Worker 被 Steam 屏蔽导致不可用，但是可以通过本地部署的方式来曲线救国，故还是有必要把错给改一改的。